### PR TITLE
Namespace in file AdminMiddleware.php error

### DIFF
--- a/src/Http/Middleware/AdminMiddleware.php
+++ b/src/Http/Middleware/AdminMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webkul\RestApi\Middleware;
+namespace Webkul\RestApi\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;


### PR DESCRIPTION
the namespace in the AdminMiddleware.php file is `Webkul\RestApi\Middleware`, but the file is located at `vendor/krayin/rest-api/src/Http/Middleware/AdminMiddleware.php`.

What was causing this warning in the screenshot in version 2.1 when running the command `composer require krayin/rest-api`

![image](https://github.com/user-attachments/assets/d6180e84-e2fd-4918-8bbf-6dd4bb1ec45c)
